### PR TITLE
Apply Windows build patch from esy

### DIFF
--- a/src/base_bigstring_stubs.c
+++ b/src/base_bigstring_stubs.c
@@ -11,7 +11,11 @@
 #endif
 
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#else
+#include <stdlib.h>
+#endif
 #include <errno.h>
 #include <assert.h>
 #include <stdint.h>
@@ -31,6 +35,21 @@
 #define bswap_64 swap64
 #elif __CYGWIN__
 #include <endian.h>
+#elif __MINGW32__
+#if defined(__GNUC__) && __GNUC__ > 4
+#define bswap_16 __builtin_bswap16
+#else
+static inline uint16_t bswap_16 (uint16_t x)
+{
+      return (x << 8) | (x >> 8);
+}
+#endif
+#define bswap_32 __builtin_bswap32
+#define bswap_64 __builtin_bswap64
+#elif _MSC_VER
+#define bswap_16 _byteswap_ushort
+#define bswap_32 _byteswap_ulong
+#define bswap_64 _byteswap_uint64
 #else
 #include <sys/types.h>
 #if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)


### PR DESCRIPTION
The original patch is from https://github.com/esy-ocaml/esy-opam-override/tree/6/packages/base_bigstring.v0.14.0 or https://github.com/fdopen/opam-repository-mingw/blob/opam2/packages/base_bigstring/base_bigstring.v0.15.0/files/base_bigstring-v0.15.0.patch . Esy and fdopen are typically MinGW on Windows.

I have also been using it for Diskuv OCaml (Windows MSVC) users for the past year.