### PR TITLE
Fix compilation error on macos

### DIFF
--- a/src/base_bigstring_stubs.c
+++ b/src/base_bigstring_stubs.c
@@ -2,9 +2,6 @@
 
 #define _GNU_SOURCE             /* recvmmsg */
 
-/* For pread/pwrite */
-#define _XOPEN_SOURCE 500
-
 /* For OpenBSD `swap` functions */
 #ifdef __OpenBSD__
 #define _BSD_SOURCE


### PR DESCRIPTION
Attempting to install `base_bigstring` on macOS failed with the following compilation error.

```
File "src/dune", line 3, characters 10-30:
3 |  (c_names base_bigstring_stubs) (preprocess (pps ppx_jane)))
              ^^^^^^^^^^^^^^^^^^^^
base_bigstring_stubs.c:222:24: error: implicit declaration of function 'memmem' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  const char *result = memmem(haystack, Long_val(v_haystack_len),
                       ^
base_bigstring_stubs.c:222:24: note: did you mean 'memset'?
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/string.h:74:7: note: 'memset' declared here
void    *memset(void *__b, int __c, size_t __len);
         ^
base_bigstring_stubs.c:222:15: warning: incompatible integer to pointer conversion initializing 'const char *' with an expression of type 'int' [-Wint-conversion]
  const char *result = memmem(haystack, Long_val(v_haystack_len),
              ^        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
```

FWIW I wasn't able to reproduce this compilation error on linux, so this is most likely a macOS only issue because of a difference in the libc implementations on linux and Mac.

Looking at the [man-page](https://man7.org/linux/man-pages/man3/memmem.3.html) for `memmem` `_GNU_SOURCE`  is the only feature test macro required to enable it, and removing `_XOPEN_SOURCE` from the c bindings helped resolve the compilation issue on macOS (the library still compiles without issues on linux).

Looking at the c header files on my local installation of macOS, I can find a definition for these feature discovery macros at `sys/cdefs.h`. The content is the same as this online copy at https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/cdefs.h#L825-L836

```c
#ifdef _XOPEN_SOURCE
#if _XOPEN_SOURCE - 0L >= 700L && (!defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE - 0L < 200809L)
#undef _POSIX_C_SOURCE
#define _POSIX_C_SOURCE         200809L
#elif _XOPEN_SOURCE - 0L >= 600L && (!defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE - 0L < 200112L)
#undef _POSIX_C_SOURCE
#define _POSIX_C_SOURCE         200112L
#elif _XOPEN_SOURCE - 0L >= 500L && (!defined(_POSIX_C_SOURCE) || _POSIX_C_SOURCE - 0L < 199506L)
#undef _POSIX_C_SOURCE
#define _POSIX_C_SOURCE         199506L
#endif
#endif
```

`_XOPEN_SOURCE` set to 500 like in the c bindings for base_bigstring will map to `_POSIX_C_SOURCE` of `199506L`. `_POSIX_C_SOURCE` being set will result in `__DARWIN_C_LEVEL` being set to the same value as seen in this snippet

https://github.com/apple/darwin-xnu/blob/2ff845c2e033bd0ff64b5b6aa6063a1f8f65aa32/bsd/sys/cdefs.h#L855-L870

```c
/*
 * Set a single macro which will always be defined and can be used to determine
 * the appropriate namespace.  For POSIX, these values will correspond to
 * _POSIX_C_SOURCE value.  Currently there are two additional levels corresponding
 * to ANSI (_ANSI_SOURCE) and Darwin extensions (_DARWIN_C_SOURCE)
 */
#define __DARWIN_C_ANSI         010000L
#define __DARWIN_C_FULL         900000L

#if   defined(_ANSI_SOURCE)
#define __DARWIN_C_LEVEL        __DARWIN_C_ANSI
#elif defined(_POSIX_C_SOURCE) && !defined(_DARWIN_C_SOURCE) && !defined(_NONSTD_SOURCE)
#define __DARWIN_C_LEVEL        _POSIX_C_SOURCE
#else
#define __DARWIN_C_LEVEL        __DARWIN_C_FULL
#endif
```

The `string.h` implementation on my local macOS install indicates that `memmem` is enabled if `#if __DARWIN_C_LEVEL >= __DARWIN_C_FULL` and this condition will fail since the bindings had `_XOPEN_SOURCE` set to 500 resulting in `__DARWIN_C_LEVEL` being mapped to `199506L`.

Online copy of apple's string.h -> https://opensource.apple.com/source/Libc/Libc-825.26/include/string.h.auto.html

**Note:** `_XOPEN_SOURCE` was used in the c bindings to enable support for `pread and pwrite` but these functions have been moved to `bigstring_unix` which lives within `core_unix` these days.